### PR TITLE
Start recording versions too, and add /recent-with-versions endpoint.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ changes.on('data', function (change) {
   var name = change.doc.name
   var version = change.doc['dist-tags'].latest
   if(name){
-    console.log(change.seq, name, version)
+    console.log('seq=' + change.seq, 'name=' + name, 'version=' + version)
     redis.lpush('npm-updated-names', name)
     redis.lpush('npm-updated-names-with-versions', name + ' ' + version)
     redis.set('npm:latest_seq', change.seq)
@@ -43,5 +43,5 @@ app.get('/recent-with-versions', function (req, res) {
 
 var port = process.env.PORT || 5001;
 app.listen(port, function() {
-  console.log('Listening on', port, ' at sequence ', since);
+  console.log('Listening on', port, 'at sequence', since);
 });

--- a/index.js
+++ b/index.js
@@ -13,9 +13,11 @@ var changes = new ChangesStream({
 
 changes.on('data', function (change) {
   var name = change.doc.name
+  var version = change.doc['dist-tags'].latest
   if(name){
-    console.log(name)
+    console.log(name, version)
     redis.lpush('npm-updated-names', name)
+    redis.lpush('npm-updated-names-with-versions', name + ' ' + version)
   }
 })
 
@@ -27,6 +29,12 @@ app.get('/', function (req, res) {
 
 app.get('/recent', function (req, res) {
   redis.lrange('npm-updated-names', 0, 5000, function (err, replies) {
+    res.json([...new Set(replies)]);
+  });
+})
+
+app.get('/recent-with-versions', function (req, res) {
+  redis.lrange('npm-updated-names-with-versions', 0, 5000, function (err, replies) {
     res.json([...new Set(replies)]);
   });
 })


### PR DESCRIPTION
Brainstorming a way to get versions back from NPM too. 